### PR TITLE
feat: Initialize Koin for iOS App

### DIFF
--- a/composeApp/src/iosMain/kotlin/org/book/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/org/book/MainViewController.kt
@@ -2,5 +2,11 @@ package org.book
 
 import androidx.compose.ui.window.ComposeUIViewController
 import coil3.compose.LocalPlatformContext
+import org.book.di.initKoin
 
-fun MainViewController() = ComposeUIViewController { App(LocalPlatformContext.current) }
+fun MainViewController() = ComposeUIViewController(
+    configure = { initKoin() }
+) {
+    App(LocalPlatformContext.current)
+}
+


### PR DESCRIPTION
This commit initializes the Koin dependency injection framework for the iOS application.

-   Modified `MainViewController` to initialize Koin using `initKoin()` before starting the Compose UI.
-   Passed the `LocalPlatformContext.current` to the `App` composable.